### PR TITLE
[orchagent] Increase SAI REDIS response timeout during init 

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -19,6 +19,7 @@ extern "C" {
 #include "timestamp.h"
 #include "sai_serialize.h"
 #include "saihelper.h"
+#include "orch.h"
 
 using namespace std;
 using namespace swss;
@@ -27,6 +28,7 @@ using namespace swss;
 #define STR(s) _STR(s)
 
 #define CONTEXT_CFG_FILE "/usr/share/sonic/hwsku/context_config.json"
+#define SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT (480*1000)
 
 // hwinfo = "INTERFACE_NAME/PHY ID", mii_ioctl_data->phy_id is a __u16
 #define HWINFO_MAX_SIZE IFNAMSIZ + 1 + 5
@@ -278,6 +280,26 @@ void initSaiRedis(const string &record_location, const std::string &record_filen
     }
     SWSS_LOG_NOTICE("Enable redis pipeline");
 
+    char *platform = getenv("platform");
+    if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
+    {
+        /* We set this long timeout in order for Orchagent to wait enough time for
+         * response from syncd. It is needed since in init, systemd syncd startup
+         * script first calls FW upgrade script (that might take up to 7 minutes
+         * in systems with Gearbox) and only then launches syncd container */
+        attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;
+        attr.value.u64 = SAI_REDIS_SYNC_OPERATION_RESPONSE_TIMEOUT;
+        status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set SAI REDIS response timeout");
+            exit(EXIT_FAILURE);
+        }
+
+        SWSS_LOG_NOTICE("SAI REDIS response timeout set successfully to %lu", attr.value.u64);
+    }
+
     attr.id = SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD;
     attr.value.s32 = SAI_REDIS_NOTIFY_SYNCD_INIT_VIEW;
     status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
@@ -288,6 +310,22 @@ void initSaiRedis(const string &record_location, const std::string &record_filen
         exit(EXIT_FAILURE);
     }
     SWSS_LOG_NOTICE("Notify syncd INIT_VIEW");
+
+    if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
+    {
+        /* Set timeout back to the default value */
+        attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;
+        attr.value.u64 = SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT;
+        status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set SAI REDIS response timeout");
+            exit(EXIT_FAILURE);
+        }
+
+        SWSS_LOG_NOTICE("SAI REDIS response timeout set successfully to %lu", attr.value.u64);
+    }
 }
 
 sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)


### PR DESCRIPTION
Increase orchagent SAI REDIS response timeout to support FW upgrade during init (Mellanox only).
This change should be merged after the following PRs were merged:
Azure/sonic-sairedis#774

Signed-off-by: liora <liora@nvidia.com>

<!--
Please make sure you have read and understood the contribution guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Increase orchagent SAI REDIS response timeout during init in order for orchagent to wait enough time for response from syncd since in init, syncd startup script first calls FW upgrade script (that might take up to 7 minutes in systems with Gearbox) and only then launches syncd.

**Why I did it**
To support FW upgrade during init flow.

**How I verified it**
I manually changed ASIC and Gearbox FW followed by hard reset in order for FW upgrade to take place on init.

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->



