### PR TITLE
Do not fail ACL rule remove flow if rule already deleted

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3617,7 +3617,9 @@ bool AclOrch::removeAclRule(string table_id, string rule_id)
     auto rule = getAclRule(table_id, rule_id);
     if (!rule)
     {
-        return false;
+        SWSS_LOG_NOTICE("ACL rule [%s] in table [%s] already deleted",
+                        rule_id.c_str(), table_id.c_str());
+        return true;
     }
 
     if (rule->hasCounter())

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -1719,4 +1719,28 @@ namespace aclorch_test
         ASSERT_TRUE(orch->m_aclOrch->removeAclRule(rule->getTableId(), rule->getId()));
     }
 
+    TEST_F(AclOrchTest, deleteNonExistingRule)
+    {
+        string tableId = "acl_table";
+        string ruleId = "acl_rule";
+
+        auto orch = createAclOrch();
+
+        // add acl table
+        auto kvfAclTable = deque<KeyOpFieldsValuesTuple>({{
+            tableId,
+            SET_COMMAND,
+            {
+                { ACL_TABLE_DESCRIPTION, "L3 table" },
+                { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
+                { ACL_TABLE_STAGE, STAGE_INGRESS },
+                { ACL_TABLE_PORTS, "1,2" }
+            }
+        }});
+
+        orch->doAclTableTask(kvfAclTable);
+
+        // try to delete non existing acl rule
+        ASSERT_TRUE(orch->m_aclOrch->removeAclRule(tableId, ruleId));
+    }
 } // namespace nsAclOrchTest


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Do not fail ACL rule remove flow if rule already deleted.

**Why I did it**
If ACL table that contains rules is being deleted, ACL table remove flow deletes the rules rules. 
In that case when ACL rule handler will be called, it should do nothing and pass.

**How I verified it**
config acl add table -p Ethernet72 -s ingress DATAACL L3
config acl update full /tmp/56521_acl_file.json
config acl add table -p Ethernet72 -s egress DATAACL L3
config acl update full 56521_acl_file.json
docker exec -it syncd sx_api_flex_acl_dump.py => verify ACL rules exist in "ACL Rules" table.

**Details if related**