### PR TITLE
[ZTP]: Add DHCP_L2 and DHCPV6_L2 traps to COPP trap map

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -86,6 +86,8 @@ static map<string, sai_hostif_trap_type_t> trap_id_map = {
     {"bfdv6", SAI_HOSTIF_TRAP_TYPE_BFDV6},
     {"src_nat_miss", SAI_HOSTIF_TRAP_TYPE_SNAT_MISS},
     {"dest_nat_miss", SAI_HOSTIF_TRAP_TYPE_DNAT_MISS},
+    {"l2dhcp", SAI_HOSTIF_TRAP_TYPE_DHCP_L2},
+    {"l2dhcpv6", SAI_HOSTIF_TRAP_TYPE_DHCPV6_L2},
     {"ldp", SAI_HOSTIF_TRAP_TYPE_LDP},
     {"bfd_micro", SAI_HOSTIF_TRAP_TYPE_BFD_MICRO},
     {"bfdv6_micro", SAI_HOSTIF_TRAP_TYPE_BFDV6_MICRO}


### PR DESCRIPTION
Signed-off-by: liora <liora@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add DHCP_L2 and DHCPV6_L2 traps to COPP trap map.

**Why I did it**
In order to enable DHCP packets to CPU on L2 interfaces. This is being used by ZTP.

**How I verified it**
I have verified both traps are registered when ZTP operation starts and being deleted when ZTP finishes its operation.

**Details if related**
