### PR TITLE
Do not allow to add port to .1Q bridge while router port deletion is not completed

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4879,6 +4879,12 @@ bool PortsOrch::addBridgePort(Port &port)
         return true;
     }
 
+    if (port.m_rif_id != 0)
+    {
+        SWSS_LOG_NOTICE("Interface %s is still a router port", port.m_alias.c_str());
+        return false;
+    }
+
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4881,7 +4881,7 @@ bool PortsOrch::addBridgePort(Port &port)
 
     if (port.m_rif_id != 0)
     {
-        SWSS_LOG_NOTICE("Interface %s is still a router port", port.m_alias.c_str());
+        SWSS_LOG_NOTICE("Interface %s is a router port", port.m_alias.c_str());
         return false;
     }
 

--- a/tests/mock_tests/mock_sai_bridge.h
+++ b/tests/mock_tests/mock_sai_bridge.h
@@ -1,0 +1,34 @@
+// Define classes and functions to mock SAI bridge functions.
+#pragma once
+
+#include <gmock/gmock.h>
+
+extern "C"
+{
+#include "sai.h"
+}
+
+// Mock class including mock functions mapping to SAI bridge functions.
+class MockSaiBridge
+{
+  public:
+    MOCK_METHOD4(create_bridge_port, sai_status_t(_Out_ sai_object_id_t *bridge_port_id,
+                                                  _In_ sai_object_id_t switch_id,
+                                                  _In_ uint32_t attr_count,
+                                                  _In_ const sai_attribute_t *attr_list));
+};
+
+// Note that before mock functions below are used, mock_sai_bridge must be
+// initialized to point to an instance of MockSaiBridge.
+MockSaiBridge *mock_sai_bridge;
+
+sai_status_t mock_create_bridge_port(_Out_ sai_object_id_t *bridge_port_id,
+                                     _In_ sai_object_id_t switch_id,
+                                     _In_ uint32_t attr_count,
+                                     _In_ const sai_attribute_t *attr_list)
+{
+    return mock_sai_bridge->create_bridge_port(bridge_port_id, switch_id, attr_count, attr_list);
+}
+
+
+

--- a/tests/mock_tests/mock_sai_bridge.h
+++ b/tests/mock_tests/mock_sai_bridge.h
@@ -12,20 +12,20 @@ extern "C"
 class MockSaiBridge
 {
   public:
-    MOCK_METHOD4(create_bridge_port, sai_status_t(_Out_ sai_object_id_t *bridge_port_id,
-                                                  _In_ sai_object_id_t switch_id,
-                                                  _In_ uint32_t attr_count,
-                                                  _In_ const sai_attribute_t *attr_list));
+    MOCK_METHOD4(create_bridge_port, sai_status_t(sai_object_id_t *bridge_port_id,
+                                                  sai_object_id_t switch_id,
+                                                  uint32_t attr_count,
+                                                  const sai_attribute_t *attr_list));
 };
 
 // Note that before mock functions below are used, mock_sai_bridge must be
 // initialized to point to an instance of MockSaiBridge.
 MockSaiBridge *mock_sai_bridge;
 
-sai_status_t mock_create_bridge_port(_Out_ sai_object_id_t *bridge_port_id,
-                                     _In_ sai_object_id_t switch_id,
-                                     _In_ uint32_t attr_count,
-                                     _In_ const sai_attribute_t *attr_list)
+sai_status_t mock_create_bridge_port(sai_object_id_t *bridge_port_id,
+                                     sai_object_id_t switch_id,
+                                     uint32_t attr_count,
+                                     const sai_attribute_t *attr_list)
 {
     return mock_sai_bridge->create_bridge_port(bridge_port_id, switch_id, attr_count, attr_list);
 }

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -7,6 +7,7 @@
 #include "mock_orchagent_main.h"
 #include "mock_table.h"
 #include "notifier.h"
+#include "mock_sai_bridge.h"
 #define private public
 #include "pfcactionhandler.h"
 #undef private
@@ -14,6 +15,8 @@
 #include <sstream>
 
 extern redisReply *mockReply;
+using ::testing::_;
+using ::testing::StrictMock;
 
 namespace portsorch_test
 {
@@ -114,6 +117,21 @@ namespace portsorch_test
     void _unhook_sai_queue_api()
     {
         sai_queue_api = pold_sai_queue_api;
+    }
+
+    sai_bridge_api_t ut_sai_bridge_api;
+    sai_bridge_api_t *org_sai_bridge_api;
+
+    void _hook_sai_bridge_api()
+    {
+        ut_sai_bridge_api = *sai_bridge_api;
+        org_sai_bridge_api = sai_bridge_api;
+        sai_bridge_api = &ut_sai_bridge_api;
+    }
+
+    void _unhook_sai_bridge_api()
+    {
+        sai_bridge_api = org_sai_bridge_api;
     }
 
     struct PortsOrchTest : public ::testing::Test
@@ -308,6 +326,48 @@ namespace portsorch_test
         entries.clear();
 
         ASSERT_FALSE(gPortsOrch->getPort(port.m_port_id, port));
+    }
+
+    /**
+     * Test case: PortsOrch::addBridgePort() does not add router port to .1Q bridge
+     */
+    TEST_F(PortsOrchTest, addBridgePortOnRouterPort)
+    {
+        _hook_sai_bridge_api();
+
+        StrictMock<MockSaiBridge> mock_sai_bridge_;
+        mock_sai_bridge = &mock_sai_bridge_;
+        sai_bridge_api->create_bridge_port = mock_create_bridge_port;
+
+        Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+
+        // Get SAI default ports to populate DB
+        auto ports = ut_helper::getInitialSaiPorts();
+
+        // Populate port table with SAI ports
+        for (const auto &it : ports)
+        {
+            portTable.set(it.first, it.second);
+        }
+
+        // Set PortConfigDone, PortInitDone
+        portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
+        portTable.set("PortInitDone", { { "lanes", "0" } });
+
+        // refill consumer
+        gPortsOrch->addExistingData(&portTable);
+        // Apply configuration : create ports
+        static_cast<Orch *>(gPortsOrch)->doTask();
+
+        // Get first port and set its rif id to simulate it is router port
+        Port port;
+        gPortsOrch->getPort("Ethernet0", port);
+        port.m_rif_id = 1;
+
+        ASSERT_FALSE(gPortsOrch->addBridgePort(port));
+        EXPECT_CALL(mock_sai_bridge_, create_bridge_port(_, _, _, _)).Times(0);
+
+        _unhook_sai_bridge_api();
     }
 
     TEST_F(PortsOrchTest, PortSupportedFecModes)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Do not allow to add port to .1Q bridge while router port deletion is not completed.

**Why I did it**
Adding router port to .1Q bridge is not allowed and will cause to errors in the driver.

**How I verified it**

Create PortChannel102 and set it as router port.
Make sure PortChannel102 has active neighbors.
Now run the following commands using a shell script (not one by one).
1. config interface ip remove PortChannel102 10.0.0.0/31
2. config vlan add 1000
3. config vlan member add 1000 PortChannel102

Follow the logs and verify addBridgePort is not perfomed until removeRouterIntfs is completed.
Unitest added as well.

**Details if related**
